### PR TITLE
Add thorough FSRS v6 unit tests

### DIFF
--- a/test/fsrs/difficulty.test.ts
+++ b/test/fsrs/difficulty.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { initDifficulty } from "../../src/fsrs/algorithm/difficulty.js";
+import { initDifficulty, updateDifficulty } from "../../src/fsrs/algorithm/difficulty.js";
 import { Rating } from "../../src/fsrs/types.js";
 import { DEFAULT_PARAMS_FSRS6 } from "../../src/fsrs/const.js";
 
@@ -8,5 +8,46 @@ describe("difficulty", () => {
     const d = initDifficulty(Rating.Good, DEFAULT_PARAMS_FSRS6);
     expect(d).toBeGreaterThanOrEqual(1);
     expect(d).toBeLessThanOrEqual(10);
+  });
+
+  test("init difficulty matches formula", () => {
+    for (const rating of [Rating.Again, Rating.Hard, Rating.Good, Rating.Easy]) {
+      const exponent = DEFAULT_PARAMS_FSRS6[5] * (rating - 1);
+      const expected = Math.min(
+        Math.max(
+          DEFAULT_PARAMS_FSRS6[4] - Math.exp(exponent) + 1,
+          1,
+        ),
+        10,
+      );
+      const d = initDifficulty(rating, DEFAULT_PARAMS_FSRS6);
+      expect(d).toBeCloseTo(expected, 8);
+    }
+  });
+
+  test("update difficulty reacts to rating", () => {
+    const initial = 5;
+    const harder = updateDifficulty(initial, Rating.Again, DEFAULT_PARAMS_FSRS6);
+    const easier = updateDifficulty(initial, Rating.Easy, DEFAULT_PARAMS_FSRS6);
+    expect(harder).toBeGreaterThan(initial);
+    expect(easier).toBeLessThan(initial);
+  });
+
+  test("update difficulty matches formula", () => {
+    const initial = 4;
+    for (const rating of [Rating.Again, Rating.Hard, Rating.Good, Rating.Easy]) {
+      const deltaD = -DEFAULT_PARAMS_FSRS6[6] * (rating - 3);
+      const prime = initial + deltaD * ((10 - initial) / 9);
+      const d0 = initDifficulty(Rating.Easy, DEFAULT_PARAMS_FSRS6);
+      const expected = Math.min(
+        Math.max(
+          DEFAULT_PARAMS_FSRS6[7] * d0 + (1 - DEFAULT_PARAMS_FSRS6[7]) * prime,
+          1,
+        ),
+        10,
+      );
+      const result = updateDifficulty(initial, rating, DEFAULT_PARAMS_FSRS6);
+      expect(result).toBeCloseTo(expected, 8);
+    }
   });
 });

--- a/test/fsrs/retrievability.test.ts
+++ b/test/fsrs/retrievability.test.ts
@@ -14,4 +14,20 @@ describe("retrievability", () => {
     const i = nextInterval(0.9, S, DEFAULT_PARAMS_FSRS6);
     expect(i).toBeCloseTo(S, 5);
   });
+
+  test("forgetting curve monotonicity and boundary", () => {
+    const S = 100;
+    const r0 = forgettingCurve(0, S, DEFAULT_PARAMS_FSRS6);
+    const rHalf = forgettingCurve(S / 2, S, DEFAULT_PARAMS_FSRS6);
+    const rFull = forgettingCurve(S, S, DEFAULT_PARAMS_FSRS6);
+    expect(r0).toBeCloseTo(1, 8);
+    expect(rHalf).toBeGreaterThan(rFull);
+    expect(rHalf).toBeLessThan(1);
+  });
+
+  test("next interval respects retention", () => {
+    const S = 100;
+    const i80 = nextInterval(0.8, S, DEFAULT_PARAMS_FSRS6);
+    expect(i80).toBeGreaterThan(S);
+  });
 });

--- a/test/fsrs/stability.test.ts
+++ b/test/fsrs/stability.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "vitest";
-import { sameDayStability } from "../../src/fsrs/algorithm/stability.js";
+import {
+  sameDayStability,
+  initStability,
+  recallStability,
+  forgetStability,
+  updateStability,
+} from "../../src/fsrs/algorithm/stability.js";
+import { initDifficulty } from "../../src/fsrs/algorithm/difficulty.js";
+import { forgettingCurve } from "../../src/fsrs/algorithm/retrievability.js";
 import { Rating } from "../../src/fsrs/types.js";
 import { DEFAULT_PARAMS_FSRS6 } from "../../src/fsrs/const.js";
 
@@ -8,5 +16,93 @@ describe("stability", () => {
     const S = 2;
     const newS = sameDayStability(S, Rating.Good, DEFAULT_PARAMS_FSRS6);
     expect(newS).toBeGreaterThan(S);
+  });
+
+  test("init stability matches parameters", () => {
+    for (const rating of [Rating.Again, Rating.Hard, Rating.Good, Rating.Easy]) {
+      expect(initStability(rating, DEFAULT_PARAMS_FSRS6)).toBe(
+        DEFAULT_PARAMS_FSRS6[rating - 1],
+      );
+    }
+  });
+
+  test("same-day stability formula", () => {
+    const S = 2;
+    const rating = Rating.Good;
+    const exponent = DEFAULT_PARAMS_FSRS6[17] * (rating - 3 + DEFAULT_PARAMS_FSRS6[18]);
+    const sInc = Math.exp(exponent) * Math.pow(S, -DEFAULT_PARAMS_FSRS6[19]);
+    const expected = S * sInc;
+    const result = sameDayStability(S, rating, DEFAULT_PARAMS_FSRS6);
+    expect(result).toBeCloseTo(expected, 8);
+  });
+
+  test("recall and forget stability formulas", () => {
+    const difficulty = 4;
+    const stability = 3;
+    const R = 0.9;
+    const rating = Rating.Good;
+    const hardPenalty = 1;
+    const easyBonus = 1;
+    const expectedRecall =
+      stability *
+        (Math.exp(DEFAULT_PARAMS_FSRS6[8]) *
+          (11 - difficulty) *
+          Math.pow(stability, -DEFAULT_PARAMS_FSRS6[9]) *
+          (Math.exp(DEFAULT_PARAMS_FSRS6[10] * (1 - R)) - 1) *
+          hardPenalty *
+          easyBonus +
+          1);
+
+    const recall = recallStability(
+      difficulty,
+      stability,
+      R,
+      rating,
+      DEFAULT_PARAMS_FSRS6,
+    );
+    expect(recall).toBeCloseTo(expectedRecall, 8);
+
+    const expectedForget =
+      DEFAULT_PARAMS_FSRS6[11] *
+      Math.pow(difficulty, -DEFAULT_PARAMS_FSRS6[12]) *
+      (Math.pow(stability + 1, DEFAULT_PARAMS_FSRS6[13]) - 1) *
+      Math.exp(DEFAULT_PARAMS_FSRS6[14] * (1 - R));
+    const forget = forgetStability(
+      difficulty,
+      stability,
+      R,
+      DEFAULT_PARAMS_FSRS6,
+    );
+    expect(forget).toBeCloseTo(expectedForget, 8);
+  });
+
+  test("update stability handles different cases", () => {
+    // new card
+    const init = updateStability(0, 0, 0, Rating.Good, DEFAULT_PARAMS_FSRS6);
+    expect(init.difficulty).toBeCloseTo(
+      initDifficulty(Rating.Good, DEFAULT_PARAMS_FSRS6),
+      8,
+    );
+    expect(init.stability).toBeCloseTo(
+      initStability(Rating.Good, DEFAULT_PARAMS_FSRS6),
+      8,
+    );
+
+    // same day review
+    const sameDay = updateStability(5, 10, 0.5, Rating.Good, DEFAULT_PARAMS_FSRS6);
+    const sameDayExpected = sameDayStability(10, Rating.Good, DEFAULT_PARAMS_FSRS6);
+    expect(sameDay.stability).toBeCloseTo(sameDayExpected, 8);
+
+    // recall
+    const recallCase = updateStability(5, 10, 5, Rating.Good, DEFAULT_PARAMS_FSRS6);
+    const R = forgettingCurve(5, 10, DEFAULT_PARAMS_FSRS6);
+    const recallExpected = recallStability(5, 10, R, Rating.Good, DEFAULT_PARAMS_FSRS6);
+    expect(recallCase.stability).toBeCloseTo(recallExpected, 8);
+
+    // forget
+    const forgetCase = updateStability(5, 10, 5, Rating.Again, DEFAULT_PARAMS_FSRS6);
+    const Rf = forgettingCurve(5, 10, DEFAULT_PARAMS_FSRS6);
+    const forgetExpected = forgetStability(5, 10, Rf, DEFAULT_PARAMS_FSRS6);
+    expect(forgetCase.stability).toBeCloseTo(forgetExpected, 8);
   });
 });


### PR DESCRIPTION
## Summary
- extend difficulty tests to verify formulas and rating effects
- add comprehensive stability tests covering init, recall, forget and update logic
- expand retrievability tests for curve behaviour and interval calculation
- verify updateDifficulty formula directly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68627b06a5d083328c1443e70144fb3f