### PR TITLE
Add manual scheduling

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,7 @@ console.log(`New stability: ${reviewedCard.stability}`);
 - Queue management for outstanding cards
 - Card interleaving strategies
 - Postpone functionality for review scheduling
+- Manual scheduling to set specific due dates
 - Built with modern ES Modules
 
 ## API Reference
@@ -116,8 +117,17 @@ import { postpone, filterSafePostponableCards } from "srs-everything";
 - `postpone(cards, now)`
   Delay the due dates of the provided cards. New scheduled days are calculated
   with a small random factor.
-- `filterSafePostponableCards(cards, now)`  
+- `filterSafePostponableCards(cards, now)`
   Filter out cards that have a high chance of being forgotten if postponed.
+
+### Manual Scheduling
+
+```typescript
+import { setDueDate } from "srs-everything";
+```
+
+- `setDueDate(card, due, now)`
+  Set a specific due time for a card and update its scheduled days accordingly.
 
 ### Priority
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,3 +31,5 @@ export { next } from "./read.js";
 export { postpone, filterSafePostponableCards } from "./postpone.js";
 
 export { applyPriority } from "./priority.js";
+
+export { setDueDate } from "./schedule.js";

--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -1,0 +1,20 @@
+import { Card } from "./types.js";
+import { msToDays } from "./utils/date.js";
+
+/**
+ * Manually set the due date of a card.
+ * The `scheduledDays` field will be updated based on the new due date
+ * and the card's last review time if available, otherwise `now`.
+ */
+export const setDueDate = <T extends Card>(
+  card: Readonly<T>,
+  due: number,
+  now: number
+): Readonly<T> => {
+  const newCard = { ...card } as T;
+  const baseTime = card.lastReview ?? now;
+  const days = msToDays(due - baseTime);
+  newCard.scheduledDays = Math.max(0, Math.round(days));
+  newCard.due = due;
+  return newCard;
+};

--- a/test/schedule.test.ts
+++ b/test/schedule.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "vitest";
+import { createCard } from "../src/card.js";
+import { CardType } from "../src/types.js";
+import { setDueDate } from "../src/schedule.js";
+
+describe("setDueDate", () => {
+  test("updates due and scheduledDays", () => {
+    const now = Date.now();
+    const card = createCard("1", CardType.Item, 50, now);
+    const future = now + 3 * 86_400_000;
+    const updated = setDueDate(card, future, now);
+    expect(updated.due).toBe(future);
+    expect(updated.scheduledDays).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- add `setDueDate` to schedule any card for a specific time
- export `setDueDate`
- document manual scheduling in README
- test `setDueDate`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863bf7246dc8332ac796d79ed4ad7ef