### PR TITLE
Add CommonJS build output

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,14 @@
   "name": "srs-everything",
   "version": "0.1.2",
   "type": "module",
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs"
     }
   },
   "files": [

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,16 @@ A modern TypeScript implementation of Spaced Repetition Systems (SRS) with suppo
 npm install srs-everything
 ```
 
+Both ES Module and CommonJS builds are provided. Use `import` in ESM projects or `require` in CJS:
+
+```typescript
+import { createCard } from "srs-everything";
+```
+
+```javascript
+const { createCard } = require("srs-everything");
+```
+
 ## Quick Start
 
 ```typescript

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,11 +2,11 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  format: "esm",
+  format: ["esm", "cjs"],
   dts: true,
   sourcemap: true,
   clean: true,
-  minify: true,
+  minify: false,
   splitting: true,
   treeshake: true,
   tsconfig: "tsconfig.json",


### PR DESCRIPTION
## Summary
- generate both ESM and CJS bundles
- expose CJS entry in `package.json`
- document both import styles in the README
- disable build minification

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68650806865083329deff8536680b096