### PR TITLE
Fix postpone interval cap

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -45,7 +45,8 @@ Remove logs for the given card `id`.
 ## Postponing
 
 ### `postpone(cards, now)`
-Delay due dates by applying a small random factor to scheduled days.
+Delay due dates by applying a small random factor to scheduled days. The result
+is clamped by each card's `maxInterval`.
 
 ### `filterSafePostponableCards(cards, now)`
 Return the subset of cards that can be postponed with a low risk of being forgotten.

--- a/readme.md
+++ b/readme.md
@@ -127,7 +127,7 @@ import { postpone, filterSafePostponableCards } from "srs-everything";
 
 - `postpone(cards, now)`
   Delay the due dates of the provided cards. New scheduled days are calculated
-  with a small random factor.
+  with a small random factor and will not exceed `maxInterval`.
 - `filterSafePostponableCards(cards, now)`
   Filter out cards that have a high chance of being forgotten if postponed.
 

--- a/src/postpone.ts
+++ b/src/postpone.ts
@@ -16,7 +16,7 @@ export const postpone = (
 
     const newScheduledDays = Math.min(
       Math.max(1, Math.ceil(scheduledDays * (1.05 + 0.05 * rand)) + delay),
-      card.maxScheduledDays
+      card.maxInterval
     );
 
     return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,6 @@ export interface BaseCard {
   priority: number;
   position: number;
   scheduledDays: number;
-  maxScheduledDays: number;
   lastReview: number | null;
   postpones: number;
   reviewLogs: ReviewLog[];

--- a/test/card.test.ts
+++ b/test/card.test.ts
@@ -31,7 +31,6 @@ describe("card helpers", () => {
       priority: 1,
       position: 0,
       scheduledDays: 0,
-      maxScheduledDays: 0,
       lastReview: now - 2 * 86_400_000,
       postpones: 0,
       reviewLogs: [],

--- a/test/grade.test.ts
+++ b/test/grade.test.ts
@@ -11,7 +11,6 @@ const baseItem = {
   priority: 0,
   position: 0,
   scheduledDays: 1,
-  maxScheduledDays: 10,
   lastReview: Date.now() - 86_400_000,
   postpones: 0,
   reviewLogs: [],

--- a/test/outstandingQueue.test.ts
+++ b/test/outstandingQueue.test.ts
@@ -14,7 +14,6 @@ const item = {
   priority: 50,
   position: 0,
   scheduledDays: 0,
-  maxScheduledDays: 10,
   lastReview: now - 86_400_000,
   postpones: 0,
   reviewLogs: [],

--- a/test/postpone.test.ts
+++ b/test/postpone.test.ts
@@ -10,7 +10,6 @@ const baseItem = {
   priority: 0,
   position: 0,
   scheduledDays: 2,
-  maxScheduledDays: 10,
   lastReview: Date.now() - 2 * 86_400_000,
   postpones: 0,
   reviewLogs: [],

--- a/test/read.test.ts
+++ b/test/read.test.ts
@@ -10,7 +10,6 @@ const baseTopic = {
   priority: 0,
   position: 0,
   scheduledDays: 0,
-  maxScheduledDays: 10,
   lastReview: null,
   postpones: 0,
   reviewLogs: [],


### PR DESCRIPTION
## Summary
- clamp postponed interval using `maxInterval`
- remove `maxScheduledDays` from card type
- update tests to drop `maxScheduledDays`
- document that postpone respects `maxInterval`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867a67b15e48332a4e94f2720d3cf62